### PR TITLE
update bioconductor installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Runing_hotspots.R

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ Install dependent packages (**data.table**, **IRanges**, **BSgenome.Hsapiens.UCS
 
 ```
 install.packages("data.table")
-source("http://bioconductor.org/biocLite.R")
-biocLite("IRanges","BSgenome.Hsapiens.UCSC.hg19")
+if (!requireNamespace("BiocManager", quietly = TRUE))
+    install.packages("BiocManager")
+BiocManager::install(c("IRanges","BSgenome.Hsapiens.UCSC.hg19"))
 ```
 
 ####Usage:

--- a/funcs.R
+++ b/funcs.R
@@ -589,10 +589,10 @@ prepmaf=function(maf,expressiontb) {
 	cat('Prepping MAF for analysis ...\n')
 	#only non-indel, coding mutations
 	
-  # coding=c('initiator_codon_variant','missense_variant','splice_acceptor_variant', 'splice_donor_variant','stop_gained','stop_lost','stop_retained_variant','synonymous_variant')
+  coding=c('initiator_codon_variant','missense_variant','splice_acceptor_variant', 'splice_donor_variant','stop_gained','stop_lost','stop_retained_variant','synonymous_variant','inframe_insertion',"inframe_deletion","frameshift_truncation")
 	
   cat(' ... Reducing MAF to protein-coding substitutions\n')
-	maf=maf[ which(maf$CANONICAL=='YES' & maf$BIOTYPE=='protein_coding'), ]
+  maf <- maf[ which(maf$Consequence %in% coding & maf$CANONICAL=='YES' & maf$BIOTYPE=='protein_coding'), ]
 	
 	# remove indels
 	# maf=maf[ which(!maf$Variant_Type%in%c('INS','DEL')), ]

--- a/hotspot_algo.R
+++ b/hotspot_algo.R
@@ -141,12 +141,11 @@ cat('\nReading in MAF...\n')
 d=read.csv(maf_fn,header=T,as.is=T,sep="\t",comment.char='#')
 d=prepmaf(d,expressiontb)
 
-
 # writing temp files to annotate MAF with trinucleotides
 write.table(d,'___temp_maf.tm',row.names=F,quote=F,sep="\t")
 system(command='python make_trinuc_maf.py ___temp_maf.tm ___temp_maf-tri.tm')
-# clean up tmp files
 d=read.csv('___temp_maf-tri.tm',header=T,as.is=T,sep="\t",comment.char='#')
+# clean up tmp files
 system(command='rm ___t*')
 cat('\nFinished prepping MAF!\n')
 
@@ -164,6 +163,7 @@ if(GENES_INTEREST) {
 }
 
 # run algorithm
+d$Chromosome <- gsub("chr","",d$Chromosome)
 cat('Running algorithm...\n')
 output=lapply(genes,binom.test_snp)
 output=do.call('rbind',output)

--- a/make_trinuc_maf.py
+++ b/make_trinuc_maf.py
@@ -33,19 +33,19 @@ for line in fromf:
 tmpf.write(join(map(lambda x: join(x, '\t'), lines), '\n'))
 tmpf.flush()
 
+
 # Make bed file of regions
 print " ... Making bed file"
 grep_ps = subprocess.Popen(["grep", "-Ev", "^#|^Hugo", "___tmp.maf"], stdout=subprocess.PIPE)
-cut_ps = subprocess.Popen("cut -f5-7".split(" "), stdin=grep_ps.stdout, stdout=subprocess.PIPE)
+cut_ps = subprocess.Popen("cut -f4-6".split(" "), stdin=grep_ps.stdout, stdout=subprocess.PIPE)
 awk_ps = subprocess.Popen(["awk", "{OFS=\"\\t\"; print $1,$2-2,$3+1}"], stdin=cut_ps.stdout, stdout=subprocess.PIPE)
 bedf = open("___tmp.bed","w")
 bedf.write(awk_ps.communicate()[0])
 bedf.close()
 
-
 # Fetch regions
 print " ... Getting regions"
-subprocess.call("bedtools getfasta -tab -fi /ifs/depot/assemblies/H.sapiens/GRCh37/gr37.fasta -bed ___tmp.bed -fo ___tmp.tsv".split(" "))
+subprocess.call("bedtools getfasta -tab -fi /Volumes/DATA/Seafile/Bioinfo-Lab-Data/Ref.Genome/hg19/hg19.fa -bed ___tmp.bed -fo ___tmp.tsv".split(" "))
 
 # Add trinuc to lines
 print " ... Adding trinucs (normalized to start from C or T)"

--- a/run.sh
+++ b/run.sh
@@ -4,6 +4,7 @@
 	--output-file=ERBBs/sig_hotspots.txt \
 	--homopolymer=FALSE
 
+mv putative_false_positive_mutations.txt ERBBs/.
 
 # ./hotspot_algo.R \
 # 	--input-maf=ERBBs/Data/ERBBS.maf \

--- a/run.sh
+++ b/run.sh
@@ -3,7 +3,8 @@
 	--input-maf=ERBBs/Data/ERBBS.maf \
 	--rdata=hotspot_algo.Rdata \
 	--output-file=ERBBs/sig_hotspots.txt \
-	--homopolymer=FALSE
+	--homopolymer=FALSE \
+	--qval=1
 
 mv putative_false_positive_mutations.txt ERBBs/.
 

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,13 @@
+./hotspot_algo.R \
+	--input-maf=ERBBs/Data/ERBBS.maf \
+	--rdata=hotspot_algo.Rdata \
+	--output-file=ERBBs/sig_hotspots.txt \
+	--homopolymer=FALSE
+
+
+# ./hotspot_algo.R \
+# 	--input-maf=ERBBs/Data/ERBBS.maf \
+# 	--rdata=hotspot_algo.Rdata \
+# 	--gene-query=ERBBs/Data/genes.txt \
+# 	--output-file=sig_hotspots.txt \
+# 	--homopolymer=FALSE

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,4 @@
+# To capture everything and then filter later on
 ./hotspot_algo.R \
 	--input-maf=ERBBs/Data/ERBBS.maf \
 	--rdata=hotspot_algo.Rdata \


### PR DESCRIPTION
For R > 3.5.0 `biocLite` is deprecated, and `BiocManager` [is the recommended way](https://www.bioconductor.org/install/) to install bioconductor packages.

Updated readme to use `BiocManager::install()`.